### PR TITLE
Fix invalid index files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ update-tests:		## Updates the code_generator_request.pb.bin for the go test case
 	protoc --debug_out="tests/enum:tests/." ./tests/enum/enum.proto
 	protoc --debug_out="tests/otheroption:tests/." ./tests/otheroption/otheroption.proto
 
+validate:
+	sysl validate
+
 syslproto:		## Rebuilds the `option protos` to go and keeps the demo directory in sync
 	protoc --go_out=. sysloption/sysloption.proto
 	rm demo/sysloption.proto && cp sysloption/sysloption.proto demo/

--- a/printer.go
+++ b/printer.go
@@ -42,6 +42,7 @@ func (p *PrinterModule) Execute(targets map[string]pgs.File, packages map[string
 			p.AddGeneratorFile(fileName, buf.String())
 		}
 	}
+	indexFile.Write([]byte("\n_:\n    ...\n"))
 	p.AddGeneratorFile("index.sysl", indexFile.String())
 	return p.Artifacts()
 }

--- a/tests/enum/index.sysl
+++ b/tests/enum/index.sysl
@@ -1,1 +1,4 @@
 import enum.sysl
+
+_:
+    ...

--- a/tests/multiplefiles/index.sysl
+++ b/tests/multiplefiles/index.sysl
@@ -1,3 +1,6 @@
 import extended.sysl
 import types.sysl
 import services.sysl
+
+_:
+    ...

--- a/tests/otheroption/index.sysl
+++ b/tests/otheroption/index.sysl
@@ -1,1 +1,4 @@
 import otheroption.sysl
+
+_:
+    ...

--- a/tests/simple/index.sysl
+++ b/tests/simple/index.sysl
@@ -1,1 +1,4 @@
 import simple.sysl
+
+_:
+    ...

--- a/tests/test/index.sysl
+++ b/tests/test/index.sysl
@@ -1,1 +1,4 @@
 import test.sysl
+
+_:
+    ...


### PR DESCRIPTION
Index files were generated without dummy applications, this PR adds dummy apps:

```
import foo.sysl

_:
    ...

```