### PR TITLE
Feature/grpc pattern

### DIFF
--- a/proto2sysl/main.go
+++ b/proto2sysl/main.go
@@ -88,7 +88,7 @@ func VisitMethod(importPrefix string, module *sysl.Module, m *protogen.Method) e
 	// Attributes
 	endpoint.Attrs = make(map[string]*sysl.Attribute)
 	endpoint.Attrs["description"] = newsysl.Attribute(cleanDescription(m.Comments))
-	endpoint.Attrs["patterns"] = newsysl.Pattern("grpc", "GRPC")
+	endpoint.Attrs["patterns"] = newsysl.Pattern("gRPC")
 	endpoint.Attrs["source_path"] = newsysl.AttributeAny(path.Join(importPrefix, m.Location.SourceFile))
 
 	module.Apps[appName].Endpoints[endpointName] = endpoint

--- a/proto2sysl/main.go
+++ b/proto2sysl/main.go
@@ -57,6 +57,7 @@ func VisitService(importPrefix string, module *sysl.Module, s *protogen.Service)
 	app.Attrs["package"] = newsysl.Attribute(pkgName)
 	app.Attrs["source_path"] = newsysl.Attribute(path.Join(importPrefix, s.Location.SourceFile))
 	app.Attrs["description"] = newsysl.Attribute(cleanDescription(s.Comments))
+	app.Attrs["patterns"] = newsysl.Pattern("gRPC")
 	module.Apps[name] = app
 	for _, e := range s.Methods {
 		if err := VisitMethod(importPrefix, module, e); err != nil {

--- a/tests/any/index.sysl
+++ b/tests/any/index.sysl
@@ -3,7 +3,7 @@ Bar[~gRPC]:
     @description = ""
     @package = "grpc_testing"
     @source_path = "tests/any/any.proto"
-    AnotherEndpoint(input <: grpc_testing.This)[~grpc, ~GRPC]:
+    AnotherEndpoint(input <: grpc_testing.This)[~gRPC]:
         @description = ""
         @source_path = "tests/any/any.proto"
         return ok <: grpc_testing.This

--- a/tests/any/index.sysl
+++ b/tests/any/index.sysl
@@ -1,5 +1,5 @@
 
-Bar:
+Bar[~gRPC]:
     @description = ""
     @package = "grpc_testing"
     @source_path = "tests/any/any.proto"

--- a/tests/date/index.sysl
+++ b/tests/date/index.sysl
@@ -1,5 +1,5 @@
 
-Bar:
+Bar[~gRPC]:
     @description = ""
     @package = "grpc_testing"
     @source_path = "tests/date/date.proto"

--- a/tests/date/index.sysl
+++ b/tests/date/index.sysl
@@ -3,7 +3,7 @@ Bar[~gRPC]:
     @description = ""
     @package = "grpc_testing"
     @source_path = "tests/date/date.proto"
-    AnotherEndpoint(input <: grpc_testing.date_)[~grpc, ~GRPC]:
+    AnotherEndpoint(input <: grpc_testing.date_)[~gRPC]:
         @description = ""
         @source_path = "tests/date/date.proto"
         return ok <: grpc_testing.date_

--- a/tests/disconnectedimport/index.sysl
+++ b/tests/disconnectedimport/index.sysl
@@ -1,5 +1,5 @@
 
-Bar:
+Bar[~gRPC]:
     @description = ""
     @package = "grpc_testing"
     @source_path = "tests/disconnectedimport/services.proto"

--- a/tests/disconnectedimport/index.sysl
+++ b/tests/disconnectedimport/index.sysl
@@ -3,7 +3,7 @@ Bar[~gRPC]:
     @description = ""
     @package = "grpc_testing"
     @source_path = "tests/disconnectedimport/services.proto"
-    AnotherEndpoint(input <: grpc_testing.Request)[~grpc, ~GRPC]:
+    AnotherEndpoint(input <: grpc_testing.Request)[~gRPC]:
         @description = ""
         @source_path = "tests/disconnectedimport/services.proto"
         return ok <: grpc_testing.Response

--- a/tests/empty/index.sysl
+++ b/tests/empty/index.sysl
@@ -3,7 +3,7 @@ Bar[~gRPC]:
     @description = ""
     @package = "grpc_testing"
     @source_path = "tests/empty/empty.proto"
-    AnotherEndpoint(input <: grpc_testing.Response)[~grpc, ~GRPC]:
+    AnotherEndpoint(input <: grpc_testing.Response)[~gRPC]:
         @description = ""
         @source_path = "tests/empty/empty.proto"
         return ok <: grpc_testing.Response

--- a/tests/empty/index.sysl
+++ b/tests/empty/index.sysl
@@ -1,5 +1,5 @@
 
-Bar:
+Bar[~gRPC]:
     @description = ""
     @package = "grpc_testing"
     @source_path = "tests/empty/empty.proto"

--- a/tests/enum/index.sysl
+++ b/tests/enum/index.sysl
@@ -1,5 +1,5 @@
 
-Bar:
+Bar[~gRPC]:
     @description = ""
     @package = "grpc_testing"
     @source_path = "tests/enum/enum.proto"

--- a/tests/enum/index.sysl
+++ b/tests/enum/index.sysl
@@ -3,7 +3,7 @@ Bar[~gRPC]:
     @description = ""
     @package = "grpc_testing"
     @source_path = "tests/enum/enum.proto"
-    AnotherEndpoint(input <: grpc_testing.Request)[~grpc, ~GRPC]:
+    AnotherEndpoint(input <: grpc_testing.Request)[~gRPC]:
         @description = ""
         @source_path = "tests/enum/enum.proto"
         return ok <: grpc_testing.Response

--- a/tests/externaltype/index.sysl
+++ b/tests/externaltype/index.sysl
@@ -3,7 +3,7 @@ Bar[~gRPC]:
     @description = ""
     @package = "grpc_testing_what"
     @source_path = "tests/externaltype/externaltype.proto"
-    AnotherEndpoint(input <: grpc_testing_what.date_)[~grpc, ~GRPC]:
+    AnotherEndpoint(input <: grpc_testing_what.date_)[~gRPC]:
         @description = ""
         @source_path = "tests/externaltype/externaltype.proto"
         return ok <: grpc_testing_what.date_
@@ -12,7 +12,7 @@ Car[~gRPC]:
     @description = ""
     @package = "grpc_testing_what"
     @source_path = "tests/externaltype/externaltype.proto"
-    AnotherEndpoint(input <: grpc_testing_what.this)[~grpc, ~GRPC]:
+    AnotherEndpoint(input <: grpc_testing_what.this)[~gRPC]:
         @description = ""
         @source_path = "tests/externaltype/externaltype.proto"
         return ok <: grpc_testing_what.this

--- a/tests/externaltype/index.sysl
+++ b/tests/externaltype/index.sysl
@@ -1,5 +1,5 @@
 
-Bar:
+Bar[~gRPC]:
     @description = ""
     @package = "grpc_testing_what"
     @source_path = "tests/externaltype/externaltype.proto"
@@ -8,7 +8,7 @@ Bar:
         @source_path = "tests/externaltype/externaltype.proto"
         return ok <: grpc_testing_what.date_
 
-Car:
+Car[~gRPC]:
     @description = ""
     @package = "grpc_testing_what"
     @source_path = "tests/externaltype/externaltype.proto"

--- a/tests/multiplefiles/index.sysl
+++ b/tests/multiplefiles/index.sysl
@@ -1,5 +1,5 @@
 
-Bar:
+Bar[~gRPC]:
     @description = ""
     @package = "grpc_testing"
     @source_path = "tests/multiplefiles/services.proto"

--- a/tests/multiplefiles/index.sysl
+++ b/tests/multiplefiles/index.sysl
@@ -3,7 +3,7 @@ Bar[~gRPC]:
     @description = ""
     @package = "grpc_testing"
     @source_path = "tests/multiplefiles/services.proto"
-    anotherEndpoint(input <: grpc_testing.Request)[~grpc, ~GRPC]:
+    anotherEndpoint(input <: grpc_testing.Request)[~gRPC]:
         @description = ""
         @source_path = "tests/multiplefiles/services.proto"
         return ok <: grpc_testing.Response

--- a/tests/otheroption/index.sysl
+++ b/tests/otheroption/index.sysl
@@ -1,5 +1,5 @@
 
-Bar:
+Bar[~gRPC]:
     @description = ""
     @package = "grpc_testing"
     @source_path = "tests/otheroption/otheroption.proto"

--- a/tests/otheroption/index.sysl
+++ b/tests/otheroption/index.sysl
@@ -3,7 +3,7 @@ Bar[~gRPC]:
     @description = ""
     @package = "grpc_testing"
     @source_path = "tests/otheroption/otheroption.proto"
-    AnotherEndpoint(input <: grpc_testing.Request)[~grpc, ~GRPC]:
+    AnotherEndpoint(input <: grpc_testing.Request)[~gRPC]:
         @description = ""
         @source_path = "tests/otheroption/otheroption.proto"
         return ok <: grpc_testing.Response

--- a/tests/simple/index.sysl
+++ b/tests/simple/index.sysl
@@ -1,5 +1,5 @@
 
-Bar:
+Bar[~gRPC]:
     @description =:
         | This is a comment before Bar
     @package = "grpc_testing"
@@ -10,7 +10,7 @@ Bar:
         @source_path = "tests/simple/simple.proto"
         return ok <: grpc_testing.Response
 
-Foo:
+Foo[~gRPC]:
     @description =:
         | This is a comment before Foo
     @package = "grpc_testing"

--- a/tests/simple/index.sysl
+++ b/tests/simple/index.sysl
@@ -4,7 +4,7 @@ Bar[~gRPC]:
         | This is a comment before Bar
     @package = "grpc_testing"
     @source_path = "tests/simple/simple.proto"
-    AnotherEndpoint(input <: grpc_testing.Request)[~grpc, ~GRPC]:
+    AnotherEndpoint(input <: grpc_testing.Request)[~gRPC]:
         @description =:
             | this is a comment before Bar.AnotherEndpoint
         @source_path = "tests/simple/simple.proto"
@@ -15,7 +15,7 @@ Foo[~gRPC]:
         | This is a comment before Foo
     @package = "grpc_testing"
     @source_path = "tests/simple/simple.proto"
-    thisEndpoint(input <: grpc_testing.Request)[~grpc, ~GRPC]:
+    thisEndpoint(input <: grpc_testing.Request)[~gRPC]:
         @description = ""
         @source_path = "tests/simple/simple.proto"
         return ok <: grpc_testing.Response

--- a/tests/test/index.sysl
+++ b/tests/test/index.sysl
@@ -1,5 +1,5 @@
 
-Foo:
+Foo[~gRPC]:
     @description = ""
     @package = "grpc_testing"
     @source_path = "tests/test/test.proto"
@@ -8,7 +8,7 @@ Foo:
         @source_path = "tests/test/test.proto"
         return ok <: grpc_testing.StreamingOutputCallResponse
 
-TestService:
+TestService[~gRPC]:
     @description =:
         | A simple service to test the various types of RPCs and experiment with
         | performance with various types of payload.

--- a/tests/test/index.sysl
+++ b/tests/test/index.sysl
@@ -3,7 +3,7 @@ Foo[~gRPC]:
     @description = ""
     @package = "grpc_testing"
     @source_path = "tests/test/test.proto"
-    Foobar(input <: grpc_testing.StreamingOutputCallRequest)[~grpc, ~GRPC]:
+    Foobar(input <: grpc_testing.StreamingOutputCallRequest)[~gRPC]:
         @description = ""
         @source_path = "tests/test/test.proto"
         return ok <: grpc_testing.StreamingOutputCallResponse
@@ -16,14 +16,14 @@ TestService[~gRPC]:
         |    rpc EmptyCall(Empty) returns (Empty);
     @package = "grpc_testing"
     @source_path = "tests/test/test.proto"
-    FullDuplexCall(input <: grpc_testing.StreamingOutputCallRequest)[~grpc, ~GRPC]:
+    FullDuplexCall(input <: grpc_testing.StreamingOutputCallRequest)[~gRPC]:
         @description =:
             | A sequence of requests with each request served by the server immediately.
             | As one request could lead to multiple responses, this interface
             | demonstrates the idea of full duplexing.
         @source_path = "tests/test/test.proto"
         return ok <: grpc_testing.StreamingOutputCallResponse
-    HalfDuplexCall(input <: grpc_testing.StreamingOutputCallRequest)[~grpc, ~GRPC]:
+    HalfDuplexCall(input <: grpc_testing.StreamingOutputCallRequest)[~gRPC]:
         @description =:
             | A sequence of requests followed by a sequence of responses.
             | The server buffers all the client requests and then serves them in order. A
@@ -31,13 +31,13 @@ TestService[~gRPC]:
             | first request.
         @source_path = "tests/test/test.proto"
         return ok <: grpc_testing.StreamingOutputCallResponse
-    StreamingInputCall(input <: grpc_testing.StreamingInputCallRequest)[~grpc, ~GRPC]:
+    StreamingInputCall(input <: grpc_testing.StreamingInputCallRequest)[~gRPC]:
         @description =:
             | A sequence of requests followed by one response (streamed upload).
             | The server returns the aggregated size of client payload as the result.
         @source_path = "tests/test/test.proto"
         return ok <: grpc_testing.StreamingInputCallResponse
-    StreamingOutputCall(input <: grpc_testing.StreamingOutputCallRequest)[~grpc, ~GRPC]:
+    StreamingOutputCall(input <: grpc_testing.StreamingOutputCallRequest)[~gRPC]:
         @description =:
             | One request followed by a sequence of responses (streamed download).
             | The server returns the payload with client desired type and sizes.


### PR DESCRIPTION
- Adds `~gRPC` patterns to applications (previously was only on endpoints)
- Replaces `grpc` and `GRPC` with `gRPC` on endpoints  